### PR TITLE
Increase precedence of 'not' operator.

### DIFF
--- a/serializer/org.muml.uppaal.serialization/src/org/muml/uppaal/serialization/UppaalSerialization.xtend
+++ b/serializer/org.muml.uppaal.serialization/src/org/muml/uppaal/serialization/UppaalSerialization.xtend
@@ -433,6 +433,8 @@ class UppaalSerialization {
 			case it instanceof PlusExpression: return 300
 			case it instanceof MinusExpression: return 300
 
+			case it instanceof NegationExpression: return 295
+
 			case it instanceof ArithmeticExpression && (
 									(it as ArithmeticExpression).operator == ArithmeticOperator::MULTIPLICATE
 									|| (it as ArithmeticExpression).operator == ArithmeticOperator::DIVIDE
@@ -455,7 +457,6 @@ class UppaalSerialization {
 			
 			case it instanceof AssignmentExpression: return 200
 			
-			case it instanceof NegationExpression: return 190
 			case it instanceof LogicalExpression && (it as LogicalExpression).operator == LogicalOperator::AND: return 180
 			case it instanceof LogicalExpression && (it as LogicalExpression).operator == LogicalOperator::OR: return 160
 			case it instanceof LogicalExpression && (it as LogicalExpression).operator == LogicalOperator::IMPLY: return 170


### PR DESCRIPTION
According to https://docs.uppaal.org/language-reference/expressions/
'not' should have close to the highest precedence of all operators.

**Example of current behavior:** The current implementation would serialize a guard condition setup like this:
`NegationExpression(ComparisonExpression(someVar,==,3))`
as
`not someVar == 3` (interpreted as `(not someVar) == 3`)
as opposed to the desired
`not (someVar == 3)`.
